### PR TITLE
False negatives in test_submission.sh

### DIFF
--- a/readme_windows.md
+++ b/readme_windows.md
@@ -9,6 +9,7 @@ If you are using Windows, you have a few choices:
    before you want to use it.
    Unzip it somewhere, then you can start it up immediately. You'll need around 2GB wherever you install it, so a 4GB
    USB drive works quite well, and makes it portable.
+   For the submission script you will have to install missing packets (unzip, diffutils) by using pacman -S <packet>
 
 2. Windows 10 only: Using the [Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux).
    This will work well for the multi-core (TBB) parts, though compatibility with OpenCL is less likely to work (WSL is very new).

--- a/test_submission.sh
+++ b/test_submission.sh
@@ -33,6 +33,7 @@ function check_for_tool {
 check_for_tool unzip;
 check_for_tool awk;
 check_for_tool grep;
+check_for_tool diff;
 check_for_tool g++;
 check_for_tool make;
 


### PR DESCRIPTION
Missing diff tool might result in a false negative in test submission.
Adding a check for the tool and a remainder in readme_windows of missing
packets